### PR TITLE
Update actions/checkout to v3

### DIFF
--- a/.github/workflows/haupt.yml
+++ b/.github/workflows/haupt.yml
@@ -27,7 +27,7 @@ jobs:
       calibration_run: ${{ steps.calibration.outputs.calibration_run }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
 
@@ -151,7 +151,7 @@ jobs:
       client_count: ${{ steps.core_client_counts.outputs.client_count }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - uses: actions/checkout@master
       if: env.SKIP_MONETDB == 'false'
@@ -271,7 +271,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: r-lib/actions/setup-r@v2
 
     - uses: actions/download-artifact@master

--- a/.github/workflows/haupt.yml
+++ b/.github/workflows/haupt.yml
@@ -151,7 +151,7 @@ jobs:
       client_count: ${{ steps.core_client_counts.outputs.client_count }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@master
 
     - uses: actions/checkout@master
       if: env.SKIP_MONETDB == 'false'

--- a/.github/workflows/haupt.yml
+++ b/.github/workflows/haupt.yml
@@ -151,23 +151,23 @@ jobs:
       client_count: ${{ steps.core_client_counts.outputs.client_count }}
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
 
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
       if: env.SKIP_MONETDB == 'false'
       with:
         token: ${{ secrets.PAT }}
         repository: MonetDB/MonetDB
         path: ./MonetDB
 
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
       if: env.SKIP_MONETDB == 'false'
       with:
         token: ${{ secrets.PAT }}
         repository: MonetDBSolutions/tpch-scripts
         path: ./tpch-scripts
 
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
       if: env.SKIP_DUCKDB == 'false'
       with:
         token: ${{ secrets.PAT }}


### PR DESCRIPTION
GitHub deprecates "old" artifacts. First attempt to update one.